### PR TITLE
Default to StandardError when error class is not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Easily create an exception with backtrace.
 ```ruby
 ActiveError.new(StandardError, "error message")
 ActiveError.new(StandardError, "error message", backtrace: caller)
+
+# default error class is StandardError
+ActiveError.new("error message")
+ActiveError.new("error message", backtrace: caller)
 ```
 
 ## Why

--- a/lib/active_error.rb
+++ b/lib/active_error.rb
@@ -1,8 +1,16 @@
 require "active_error/version"
 
 module ActiveError
-  def self.new(error, message = nil, backtrace: caller)
-    exception = error.new(message)
+  def self.new(error_class_or_message=nil, message = nil, backtrace: caller)
+    if error_class_or_message.is_a? Class
+      error_class = error_class_or_message
+      error_msg = message
+    else
+      error_class =  StandardError
+      error_msg = error_class_or_message.to_s
+    end
+
+    exception = error_class.new(error_msg)
     exception.set_backtrace(backtrace)
     exception
   end

--- a/lib/active_error.rb
+++ b/lib/active_error.rb
@@ -1,16 +1,15 @@
 require "active_error/version"
 
 module ActiveError
-  def self.new(error_class_or_message=nil, message = nil, backtrace: caller)
+  def self.new(error_class_or_message = nil, message = nil, backtrace: caller)
     if error_class_or_message.is_a? Class
       error_class = error_class_or_message
-      error_msg = message
     else
-      error_class =  StandardError
-      error_msg = error_class_or_message.to_s
+      error_class = StandardError
+      message = error_class_or_message.to_s
     end
 
-    exception = error_class.new(error_msg)
+    exception = error_class.new(message)
     exception.set_backtrace(backtrace)
     exception
   end

--- a/spec/active_error_spec.rb
+++ b/spec/active_error_spec.rb
@@ -6,16 +6,38 @@ RSpec.describe ActiveError do
   end
 
   describe ".new" do
-    it "create an exception with message" do
-      exception = ActiveError.new(StandardError, "failed lor")
+    context 'error class is given' do
+      it "create an exception with message" do
+        exception = ActiveError.new(StandardError, "failed lor")
 
-      expect(exception.message).to eq "failed lor"
+        expect(exception.message).to eq "failed lor"
+      end
+
+      it "create an exception with message and backtrace" do
+        exception = ActiveError.new(StandardError, "failed lor", backtrace: ["1", "2", "3"])
+
+        expect(exception.backtrace).to eq ["1", "2", "3"]
+      end
     end
 
-    it "create an exception with message and backtrace" do
-      exception = ActiveError.new(StandardError, "failed lor", backtrace: ["1", "2", "3"])
+    context 'error class is not given' do
+      it 'defaults to StandardError' do
+        exception = ActiveError.new('failed lor')
 
-      expect(exception.backtrace).to eq ["1", "2", "3"]
+        expect(exception).to be_instance_of StandardError
+      end
+
+      it 'accepts message as first argument' do
+        exception = ActiveError.new('failed lor')
+
+        expect(exception.message).to eq 'failed lor'
+      end
+
+      it 'accepts backtrace as second argument' do
+        exception = ActiveError.new('failed lor', backtrace: %w(1 2 3))
+
+        expect(exception.backtrace).to eq %w(1 2 3)
+      end
     end
   end
 end

--- a/spec/active_error_spec.rb
+++ b/spec/active_error_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActiveError do
   end
 
   describe ".new" do
-    context "error class is given" do
+    context "when error class is given" do
       it "create an exception with message" do
         exception = ActiveError.new(StandardError, "failed lor")
 
@@ -20,11 +20,11 @@ RSpec.describe ActiveError do
       end
     end
 
-    context "error class is not given" do
+    context "when error class is not given" do
       it "defaults to StandardError" do
         exception = ActiveError.new("failed lor")
 
-        expect(exception).to be_instance_of StandardError
+        expect(exception).to be_a StandardError
       end
 
       it "accepts message as first argument" do
@@ -37,6 +37,12 @@ RSpec.describe ActiveError do
         exception = ActiveError.new("failed lor", backtrace: %w(1 2 3))
 
         expect(exception.backtrace).to eq %w(1 2 3)
+      end
+
+      it "specifies error messages twice, default to first one" do
+        exception = ActiveError.new("failed lor", "failed lah")
+
+        expect(exception.message).to eq "failed lor"
       end
     end
   end

--- a/spec/active_error_spec.rb
+++ b/spec/active_error_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActiveError do
   end
 
   describe ".new" do
-    context 'error class is given' do
+    context "error class is given" do
       it "create an exception with message" do
         exception = ActiveError.new(StandardError, "failed lor")
 
@@ -20,21 +20,21 @@ RSpec.describe ActiveError do
       end
     end
 
-    context 'error class is not given' do
-      it 'defaults to StandardError' do
-        exception = ActiveError.new('failed lor')
+    context "error class is not given" do
+      it "defaults to StandardError" do
+        exception = ActiveError.new("failed lor")
 
         expect(exception).to be_instance_of StandardError
       end
 
-      it 'accepts message as first argument' do
-        exception = ActiveError.new('failed lor')
+      it "accepts message as first argument" do
+        exception = ActiveError.new("failed lor")
 
-        expect(exception.message).to eq 'failed lor'
+        expect(exception.message).to eq "failed lor"
       end
 
-      it 'accepts backtrace as second argument' do
-        exception = ActiveError.new('failed lor', backtrace: %w(1 2 3))
+      it "accepts backtrace as second argument" do
+        exception = ActiveError.new("failed lor", backtrace: %w(1 2 3))
 
         expect(exception.backtrace).to eq %w(1 2 3)
       end


### PR DESCRIPTION
@JuanitoFatas 

This PR will allow it to skip specifying the error class, and default to StandardError.

```
ActiveError.new("error message")
ActiveError.new("error message", backtrace: caller)
```
